### PR TITLE
Extract usages of Type.{to,of}_string to Codec

### DIFF
--- a/src/irmin-rpc/codec_intf.ml
+++ b/src/irmin-rpc/codec_intf.ml
@@ -6,7 +6,23 @@ type info_struct = Builder.Irmin.Info.struct_t
 
 type commit_struct = Builder.Irmin.Commit.struct_t
 
+module type SERIALISABLE = sig
+  type t
+
+  val encode : t -> string
+
+  val decode : string -> (t, [> `Msg of string ]) result
+end
+
 module type MAKER = functor (Store : Irmin.S) -> sig
+  module Branch : SERIALISABLE with type t = Store.branch
+
+  module Key : SERIALISABLE with type t = Store.key
+
+  module Hash : SERIALISABLE with type t = Store.hash
+
+  module Contents : SERIALISABLE with type t = Store.contents
+
   val encode_tree :
     tree_struct builder_t -> Store.key -> Store.tree -> unit Lwt.t
 


### PR DESCRIPTION
Mostly just code cleanup.

From this point, it's fairly similar to provide a `Make` functor
parameterised over the codecs that it uses, in case we ever want
non-generic forms for performance reasons.