### PR TITLE
Require explicit codec for endpoints

### DIFF
--- a/examples/client.ml
+++ b/examples/client.ml
@@ -1,12 +1,7 @@
 open Lwt.Infix
 module Store = Irmin_unix.Git.Mem.KV (Irmin.Contents.String)
-
 module Rpc =
-  Irmin_rpc_unix.Make
-    (Store)
-    (struct
-      let remote = Store.remote
-    end)
+  Irmin_rpc_unix.Make (Store) (Irmin_rpc_unix.Git_unix_endpoint_codec)
 
 (* This was printed when running the server example *)
 let uri =

--- a/examples/server.ml
+++ b/examples/server.ml
@@ -1,12 +1,7 @@
 open Lwt.Infix
 module Store = Irmin_unix.Git.Mem.KV (Irmin.Contents.String)
-
 module Rpc =
-  Irmin_rpc_unix.Make
-    (Store)
-    (struct
-      let remote = Store.remote
-    end)
+  Irmin_rpc_unix.Make (Store) (Irmin_rpc_unix.Git_unix_endpoint_codec)
 
 let main =
   Store.Repo.v (Irmin_mem.config ()) >>= fun repo ->

--- a/irmin-rpc-unix.opam
+++ b/irmin-rpc-unix.opam
@@ -25,9 +25,9 @@ depends:
   "irmin-rpc"
   "irmin-unix"
   "lwt"
+  "sexplib0"
   "uri"
   "alcotest-lwt" {with-test & >= "1.1.0"}
-  "sexplib0" {with-test}
 ]
 
 synopsis: "Cap'n Proto RPC client/server for Irmin"

--- a/irmin-rpc-unix.opam
+++ b/irmin-rpc-unix.opam
@@ -27,6 +27,7 @@ depends:
   "lwt"
   "uri"
   "alcotest-lwt" {with-test & >= "1.1.0"}
+  "sexplib0" {with-test}
 ]
 
 synopsis: "Cap'n Proto RPC client/server for Irmin"

--- a/src/irmin-rpc-mirage/irmin_rpc_mirage.mli
+++ b/src/irmin-rpc-mirage/irmin_rpc_mirage.mli
@@ -1,5 +1,7 @@
 module Make
     (Store : Irmin.S)
+    (Endpoint_codec : Irmin_rpc.Codec.SERIALISABLE
+                        with type t = Store.Private.Sync.endpoint)
     (Random : Mirage_random.S)
     (Mclock : Mirage_clock.MCLOCK)
     (Pclock : Mirage_clock.PCLOCK)

--- a/src/irmin-rpc-unix/irmin_rpc_unix.mli
+++ b/src/irmin-rpc-unix/irmin_rpc_unix.mli
@@ -1,4 +1,10 @@
-module Make (Store : Irmin.S) (Remote : Irmin_rpc.REMOTE) : sig
+module Git_unix_endpoint_codec :
+  Irmin_rpc.Codec.SERIALISABLE with type t = Git_unix.endpoint
+
+module Make
+    (Store : Irmin.S)
+    (Endpoint_codec : Irmin_rpc.Codec.SERIALISABLE
+                        with type t = Store.Private.Sync.endpoint) : sig
   module Rpc : Irmin_rpc.S with module Store = Store
 
   module Server : sig

--- a/src/irmin-rpc/client_intf.ml
+++ b/src/irmin-rpc/client_intf.ml
@@ -5,6 +5,8 @@ module type S = sig
 
   type t = capability
 
+  type endpoint = Store.Private.Sync.endpoint
+
   val get : t -> ?branch:Store.branch -> Store.key -> Store.contents Lwt.t
 
   val find :
@@ -58,7 +60,7 @@ module type S = sig
     val clone :
       t ->
       ?branch:Store.branch ->
-      string ->
+      endpoint ->
       (Store.Hash.t, [ `Msg of string ]) result Lwt.t
 
     val pull :
@@ -66,7 +68,7 @@ module type S = sig
       ?branch:Store.branch ->
       author:string ->
       message:string ->
-      string ->
+      endpoint ->
       (Store.Hash.t, [ `Msg of string ]) result Lwt.t
     (** [pull t ~branch ~author ~message remote] pulls from the given remote
         into the specified branch. A local merge commit is constructed using the
@@ -75,7 +77,7 @@ module type S = sig
     val push :
       t ->
       ?branch:Store.branch ->
-      string ->
+      endpoint ->
       (unit, [ `Msg of string ]) result Lwt.t
   end
 
@@ -97,5 +99,9 @@ end
 module type Client = sig
   module type S = S
 
-  module Make (Store : Irmin.S) : S with module Store = Store
+  module Make
+      (Store : Irmin.S)
+      (Endpoint_codec : Codec.SERIALISABLE
+                          with type t = Store.Private.Sync.endpoint) :
+    S with module Store = Store
 end

--- a/src/irmin-rpc/codec_intf.ml
+++ b/src/irmin-rpc/codec_intf.ml
@@ -34,6 +34,8 @@ module type MAKER = functor (Store : Irmin.S) -> sig
 end
 
 module type Codec = sig
+  module type SERIALISABLE = SERIALISABLE
+
   module type MAKER = MAKER
 
   module Make : MAKER

--- a/src/irmin-rpc/irmin_api.capnp
+++ b/src/irmin-rpc/irmin_api.capnp
@@ -1,6 +1,7 @@
 @0x893d5c0632fd10a9;
 
 interface Irmin {
+
   struct Branch {
       name @0 :Text;
       head @1 :Commit;
@@ -42,9 +43,9 @@ interface Irmin {
   remove @2 (branch :Text, key :Text, author :Text, message :Text) -> (result :Commit);
   findTree @3 (branch :Text, key :Text) -> (result :Tree);
   setTree @4 (branch :Text, key :Text, tree :Tree, author :Text, message :Text) -> (result :Commit);
-  push @5 (branch :Text, remote :Text) -> ();
-  pull @6 (branch :Text, remote :Text, author :Text, message :Text) -> (result :Commit);
-  clone @7 (branch :Text, remote :Text) -> (result :Commit);
+  push @5 (branch :Text, endpoint :Data) -> ();
+  pull @6 (branch :Text, endpoint :Data, author :Text, message :Text) -> (result :Commit);
+  clone @7 (branch :Text, endpoint :Data) -> (result :Commit);
   merge @8 (branchFrom :Text, branchInto :Text, author :Text, message :Text) -> (result :Commit);
   commitInfo @9 (hash :Data) -> (result :Info);
   snapshot @10 (branch :Text) -> (result :Data);

--- a/src/irmin-rpc/irmin_rpc_intf.ml
+++ b/src/irmin-rpc/irmin_rpc_intf.ml
@@ -1,9 +1,5 @@
 type t = Raw.Client.Irmin.t Capnp_rpc_lwt.Capability.t
 
-module type REMOTE = sig
-  val remote : ?headers:Cohttp.Header.t -> string -> Irmin.remote
-end
-
 module type INFO = sig
   val info :
     ?author:string -> ('a, Format.formatter, unit, Irmin.Info.f) format4 -> 'a
@@ -15,13 +11,14 @@ module type S = sig
   val local : Store.repo -> t
 end
 
-module type MAKER = functor (Store : Irmin.S) (_ : INFO) (_ : REMOTE) ->
-  S with module Store = Store
+module type MAKER = functor
+  (Store : Irmin.S)
+  (_ : INFO)
+  (Endpoint_codec : Codec.SERIALISABLE with type t = Store.Private.Sync.endpoint)
+  -> S with module Store = Store
 
 module type Irmin_rpc = sig
   type nonrec t = t
-
-  module type REMOTE = REMOTE
 
   module type INFO = INFO
 
@@ -32,4 +29,5 @@ module type Irmin_rpc = sig
   module Make : MAKER
 
   module Client = Client
+  module Codec = Codec
 end

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,5 @@
 (test
  (name test)
+ (package irmin-rpc-unix)
  (libraries alcotest alcotest-lwt digestif.c cohttp irmin irmin-git
-   irmin-rpc-unix irmin-unix logs lwt lwt.unix))
+   irmin-rpc-unix irmin-unix logs lwt lwt.unix sexplib0))


### PR DESCRIPTION
This replaces the previous solution which was serialising `Irmin_unix` URI strings to be passed to be used in constructing remotes at the server (`?headers:Cohttp.Header.t -> string -> remote`). The new mechanism is more generic, allowing e.g. Conduit endpoints to be used as remote endpoints rather than URI strings.

There are two limitations remaining with the current solution:

- `Git_mirage.endpoint` is not currently serialisable, as it contains a `Conduit_mirage.t`. As a result, there is no convenient way to use RPC to speak to a remote `Irmin_mirage_git` store (this was already the case).

- The CLI "resolvers" being used in `irmin-rpc-unix/bin/main.ml` (piggy-backed from `Irmin_unix`) are no longer sufficient to provide access to the `SYNC` API. A solution here would be to extend/modify the resolvers in `mirage/irmin`, but that's not a priority.