### PR TITLE
Refactor the server API

### DIFF
--- a/examples/server.ml
+++ b/examples/server.ml
@@ -5,9 +5,9 @@ module Rpc =
 
 let main =
   Store.Repo.v (Irmin_mem.config ()) >>= fun repo ->
-  Rpc.Server.create ~secret_key:`Ephemeral (`TCP ("127.0.0.1", 9999)) repo
+  Rpc.Server.serve ~secret_key:`Ephemeral (`TCP ("127.0.0.1", 9999)) repo
   >>= fun server ->
   Lwt_io.printl (Uri.to_string (Rpc.Server.uri server)) >>= fun () ->
-  Rpc.Server.run server
+  fst (Lwt.wait ())
 
 let () = Lwt_main.run main

--- a/src/irmin-rpc-unix/bin/main.ml
+++ b/src/irmin-rpc-unix/bin/main.ml
@@ -26,7 +26,7 @@ let run host port (Irmin_unix.Resolver.S ((module Store), store, _)) secret_key
   in
   let p =
     store >>= fun store ->
-    Rpc.Server.create ~secret_key (`TCP (host, port)) (Store.repo store)
+    Rpc.Server.serve ~secret_key (`TCP (host, port)) (Store.repo store)
     >>= fun server ->
     let () =
       match address_file with
@@ -38,7 +38,7 @@ let run host port (Irmin_unix.Resolver.S ((module Store), store, _)) secret_key
           Printf.printf "Serving on: %s\n%!"
             (Uri.to_string (Rpc.Server.uri server))
     in
-    Rpc.Server.run server
+    fst (Lwt.wait ())
   in
   Lwt_main.run p
 

--- a/src/irmin-rpc-unix/irmin_rpc_unix.ml
+++ b/src/irmin-rpc-unix/irmin_rpc_unix.ml
@@ -35,16 +35,14 @@ struct
 
     let uri { uri; _ } = uri
 
-    let create ?backlog ~secret_key ?serve_tls addr repo =
+    let serve ?backlog ?switch ?secure:serve_tls ~secret_key addr repo =
       let config =
         Capnp_rpc_unix.Vat_config.create ?backlog ~secret_key ?serve_tls addr
       in
       let service_id = Capnp_rpc_unix.Vat_config.derived_id config "main" in
       let restore = Capnp_rpc_net.Restorer.single service_id (Rpc.local repo) in
-      Capnp_rpc_unix.serve config ~restore >|= fun vat ->
+      Capnp_rpc_unix.serve ?switch ~restore config >|= fun vat ->
       { uri = Capnp_rpc_unix.Vat.sturdy_uri vat service_id }
-
-    let run _t = fst (Lwt.wait ())
   end
 
   module Client = struct

--- a/src/irmin-rpc-unix/irmin_rpc_unix.mli
+++ b/src/irmin-rpc-unix/irmin_rpc_unix.mli
@@ -12,15 +12,26 @@ module Make
 
     val uri : t -> Uri.t
 
-    val create :
+    val serve :
       ?backlog:int ->
+      ?switch:Lwt_switch.t ->
+      ?secure:bool ->
       secret_key:[< `File of string | `PEM of string | `Ephemeral ] ->
-      ?serve_tls:bool ->
       Capnp_rpc_unix.Network.Location.t ->
       Store.repo ->
       t Lwt.t
+    (** Initialise an Irmin RPC server hosted at the given network location
+        serving data from the given repository.
 
-    val run : t -> unit Lwt.t
+        - Backlog is the maximal number of pending requests (passed to
+          {!Unix.listen}).
+
+        - If [secure] is true (default), the server performs a TLS handshake
+          using the provided [secret_key]. Otherwise, the server will accept any
+          unencrypted incoming connection.
+
+        - Turning off the supplied Lwt switch will terminate the server
+          asynchronously. *)
   end
 
   module Client : sig


### PR DESCRIPTION
Previously, the server API was `Server.{create,run}`, where `create` actually spawns the service asynchronously and `run` just waits forever on an abstract type returned by `create`. This suggests that the service only begins at the point when `run` is actually called (which is not easily achievable with the Capnp API).

The proposed API is `Server.serve`, which creates and 'runs' the server in one call (matching the underlying Capnp API for serving vats). I've added some documentation explaining the semantics while I'm at it.