### PR TITLE
Add Tx capability, add some benchmarks

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.17.0
+version = 0.16.0
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.16.0
+version = 0.17.0
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
 
+- Create `Tx` API for working with mutable trees (#14, @zshipko)
 - API overhaul(#13, @zshipko + @CraigFe)
 - Added more logging (#13, @zshipko)

--- a/bench/basic.ml
+++ b/bench/basic.ml
@@ -4,7 +4,7 @@ module Store =
   Irmin_pack.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
-    (Irmin.Hash.SHA1)
+    (Irmin.Hash.BLAKE2B)
 module Rpc =
   Irmin_rpc_unix.Make
     (Store)

--- a/bench/basic.ml
+++ b/bench/basic.ml
@@ -1,0 +1,39 @@
+open Bench_common
+open Lwt.Syntax
+module Store =
+  Irmin_pack.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+    (Irmin.Path.String_list)
+    (Irmin.Branch.String)
+    (Irmin.Hash.SHA1)
+module Rpc =
+  Irmin_rpc_unix.Make
+    (Store)
+    (Irmin_rpc.Config.Remote.None (Store))
+    (Irmin_rpc.Config.Pack.Make (Store))
+
+let rec rpc_add tx n =
+  if n = 0 then Lwt.return tx
+  else
+    let s = random_string (Random.int 1024) in
+    let key = [ random_key () ] in
+    let* tx = Rpc.Client.Tree.Local.add tx key s in
+    rpc_add tx (n - 1)
+
+let rpc url =
+  let* n, () =
+    with_timer (fun () ->
+        let* client = Rpc.Client.connect (Uri.of_string url) in
+        let* repo = Rpc.Client.repo client in
+        let* master = Rpc.Client.Store.master repo in
+        let tx = Rpc.Client.Tree.Local.empty in
+        let* tx = rpc_add tx 100000 in
+        let* tree = Rpc.Client.Tree.Local.to_tree repo tx in
+        let* () =
+          Rpc.Client.Store.set_tree master ~info:(Irmin_unix.info "test") []
+            tree
+        in
+        Lwt.return_unit)
+  in
+  Lwt_io.printf "%f\n" n
+
+let () = Lwt_main.run (rpc Sys.argv.(1))

--- a/bench/basic.ml
+++ b/bench/basic.ml
@@ -14,7 +14,7 @@ module Rpc =
 let rec add tree n =
   if n = 0 then Lwt.return_unit
   else
-    let s = String.make 1024 'A' in
+    let s = random_string 512 in
     let key = [ string_of_int n ] in
     let* () = Rpc.Client.Tx.add tree key s in
     add tree (n - 1)

--- a/bench/basic.ml
+++ b/bench/basic.ml
@@ -19,14 +19,14 @@ let rec add tree n =
     let* () = Rpc.Client.Tx.add tree key s in
     add tree (n - 1)
 
-let rpc url =
+let rpc url n =
   let* n, () =
     let* client = Rpc.Client.connect (Uri.of_string url) in
     let* repo = Rpc.Client.repo client in
     let* master = Rpc.Client.Store.master repo in
     let* tx = Rpc.Client.Tx.empty repo in
     with_timer (fun () ->
-        let* () = add tx 100000 in
+        let* () = add tx n in
         let* () =
           Rpc.Client.Tx.commit tx master [ "a" ] ~info:(Irmin_unix.info "test")
         in
@@ -35,5 +35,8 @@ let rpc url =
   Lwt_io.printf "%f\n" n
 
 let () =
+  let n =
+    if Array.length Sys.argv > 2 then int_of_string Sys.argv.(2) else 10_000
+  in
   Memtrace.trace_if_requested ();
-  Lwt_main.run (rpc Sys.argv.(1))
+  Lwt_main.run (rpc Sys.argv.(1) n)

--- a/bench/bench_common.ml
+++ b/bench/bench_common.ml
@@ -103,16 +103,16 @@ struct
     in
     aux 0 []
 
-  let chain_tree (tree : Client.tx) depth path =
+  let chain_tree (tree : Client.Tree.Local.t) depth path =
     let k = path @ key depth in
-    Client.Tx.add tree k (random_blob ())
+    Client.Tree.Local.add tree k (random_blob ())
 
   let add_chain_trees depth nb tree =
     let path = key 2 in
     let rec aux i tree =
       if i >= nb then Lwt.return tree
       else
-        let* () = chain_tree tree depth path in
+        let* tree = chain_tree tree depth path in
         aux (i + 1) tree
     in
     aux 0 tree
@@ -122,7 +122,7 @@ struct
       if i >= width then Lwt.return tree
       else
         let k = path @ [ random_key () ] in
-        let* () = Client.Tx.add tree k (random_blob ()) in
+        let* tree = Client.Tree.Local.add tree k (random_blob ()) in
         aux (i + 1) tree
     in
     aux 0 tree

--- a/bench/bench_common.ml
+++ b/bench/bench_common.ml
@@ -103,16 +103,16 @@ struct
     in
     aux 0 []
 
-  let chain_tree tree depth path =
+  let chain_tree (tree : Client.tx) depth path =
     let k = path @ key depth in
-    Client.Tree.add tree k (random_blob ())
+    Client.Tx.add tree k (random_blob ())
 
   let add_chain_trees depth nb tree =
     let path = key 2 in
     let rec aux i tree =
       if i >= nb then Lwt.return tree
       else
-        let* tree = chain_tree tree depth path in
+        let* () = chain_tree tree depth path in
         aux (i + 1) tree
     in
     aux 0 tree
@@ -122,7 +122,7 @@ struct
       if i >= width then Lwt.return tree
       else
         let k = path @ [ random_key () ] in
-        let* tree = Client.Tree.add tree k (random_blob ()) in
+        let* () = Client.Tx.add tree k (random_blob ()) in
         aux (i + 1) tree
     in
     aux 0 tree

--- a/bench/bench_common.ml
+++ b/bench/bench_common.ml
@@ -1,0 +1,140 @@
+let ( let* ) x f = Lwt.bind x f
+
+let ( let+ ) x f = Lwt.map f x
+
+let reporter ?(prefix = "") () =
+  let report src level ~over k msgf =
+    let k _ =
+      over ();
+      k ()
+    in
+    let ppf = match level with Logs.App -> Fmt.stdout | _ -> Fmt.stderr in
+    let with_stamp h _tags k fmt =
+      let dt = Unix.gettimeofday () in
+      Fmt.kpf k ppf
+        ("%s%+04.0fus %a %a @[" ^^ fmt ^^ "@]@.")
+        prefix dt Logs_fmt.pp_header (level, h)
+        Fmt.(styled `Magenta string)
+        (Logs.Src.name src)
+    in
+    msgf @@ fun ?header ?tags fmt -> with_stamp header tags k fmt
+  in
+  { Logs.report }
+
+let () =
+  Logs.set_level (Some Logs.Info);
+  Logs.set_reporter (reporter ())
+
+let reset_stats () =
+  Index.Stats.reset_stats ();
+  Irmin_pack.Stats.reset_stats ()
+
+let random_char () = char_of_int (1 + Random.int 255)
+
+let random_string n = String.init n (fun _i -> random_char ())
+
+let random_blob () = random_string 10
+
+let random_key () = random_string 5
+
+let with_timer f =
+  let t0 = Sys.time () in
+  let+ a = f () in
+  let t1 = Sys.time () -. t0 in
+  (t1, a)
+
+module Conf = struct
+  let entries = 32
+
+  let stable_hash = 256
+end
+
+let info () =
+  let date = Int64.of_float (Unix.gettimeofday ()) in
+  let author = Printf.sprintf "TESTS" in
+  Irmin.Info.v ~date ~author "commit "
+
+module FSHelper = struct
+  let file f =
+    try (Unix.stat f).st_size with Unix.Unix_error (Unix.ENOENT, _, _) -> 0
+
+  let dict root = file (Irmin_pack.Layout.dict ~root) / 1024 / 1024
+
+  let pack root = file (Irmin_pack.Layout.pack ~root) / 1024 / 1024
+
+  let index root =
+    let index_dir = Filename.concat root "index" in
+    let a = file (Filename.concat index_dir "data") in
+    let b = file (Filename.concat index_dir "log") in
+    let c = file (Filename.concat index_dir "log_async") in
+    (a + b + c) / 1024 / 1024
+
+  let size root = dict root + pack root + index root
+
+  let get_size root = size root
+
+  let print_size_layers root =
+    let dt = Unix.gettimeofday () in
+    let upper1 = Filename.concat root "upper1" in
+    let upper0 = Filename.concat root "upper0" in
+    let lower = Filename.concat root "lower" in
+    Fmt.epr "%+04.0fus: upper1 = %d M, upper0 = %d M, lower = %d M\n%!" dt
+      (size upper1) (size upper0) (size lower)
+
+  let rm_dir root =
+    if Sys.file_exists root then (
+      let cmd = Printf.sprintf "rm -rf %s" root in
+      Logs.info (fun l -> l "exec: %s\n%!" cmd);
+      let _ = Sys.command cmd in
+      ())
+end
+
+module Generate_trees
+    (Client : Irmin_rpc.Client.S
+                with type contents = string
+                 and type key = string list) =
+struct
+  let key depth =
+    let rec aux i acc =
+      if i >= depth then acc
+      else
+        let k = random_key () in
+        aux (i + 1) (k :: acc)
+    in
+    aux 0 []
+
+  let chain_tree tree depth path =
+    let k = path @ key depth in
+    Client.Tree.add tree k (random_blob ())
+
+  let add_chain_trees depth nb tree =
+    let path = key 2 in
+    let rec aux i tree =
+      if i >= nb then Lwt.return tree
+      else
+        let* tree = chain_tree tree depth path in
+        aux (i + 1) tree
+    in
+    aux 0 tree
+
+  let large_tree path tree width =
+    let rec aux i tree =
+      if i >= width then Lwt.return tree
+      else
+        let k = path @ [ random_key () ] in
+        let* tree = Client.Tree.add tree k (random_blob ()) in
+        aux (i + 1) tree
+    in
+    aux 0 tree
+
+  let add_large_trees width nb tree =
+    let path = key 1 in
+    let rec aux i tree =
+      if i >= nb then Lwt.return tree
+      else
+        let path = path @ [ random_key () ] in
+        let* tree = large_tree path tree width in
+        aux (i + 1) tree
+    in
+    aux 0 tree
+end

--- a/bench/bench_common.ml
+++ b/bench/bench_common.ml
@@ -22,7 +22,7 @@ let reporter ?(prefix = "") () =
   { Logs.report }
 
 let () =
-  Logs.set_level (Some Logs.Info);
+  Logs.set_level (Some Logs.App);
   Logs.set_reporter (reporter ())
 
 let reset_stats () =

--- a/bench/dune
+++ b/bench/dune
@@ -12,6 +12,5 @@
  (package irmin-rpc-unix)
  (preprocess
   (pps ppx_deriving_yojson ppx_repr))
- (libraries irmin-rpc-unix lwt
-   unix cmdliner logs yojson ppx_deriving_yojson memtrace repr ppx_repr
-   bench_common))
+ (libraries irmin-rpc-unix lwt unix cmdliner logs yojson ppx_deriving_yojson
+   memtrace repr ppx_repr bench_common))

--- a/bench/dune
+++ b/bench/dune
@@ -1,0 +1,17 @@
+(library
+ (name bench_common)
+ (modules bench_common)
+ (libraries irmin-pack irmin-rpc-unix unix))
+
+;; Require the above executables to compile during tests
+
+(executable
+ (name tree)
+ (modules tree)
+ (public_name tree)
+ (package irmin-rpc-unix)
+ (preprocess
+  (pps ppx_deriving_yojson ppx_repr))
+ (libraries irmin-rpc-unix lwt
+   unix cmdliner logs yojson ppx_deriving_yojson memtrace repr ppx_repr
+   bench_common))

--- a/bench/dune
+++ b/bench/dune
@@ -14,3 +14,13 @@
   (pps ppx_deriving_yojson ppx_repr))
  (libraries irmin-rpc-unix lwt unix cmdliner logs yojson ppx_deriving_yojson
    memtrace repr ppx_repr bench_common))
+
+(executable
+ (name basic)
+ (modules basic)
+ (public_name basic)
+ (package irmin-rpc-unix)
+ (preprocess
+  (pps ppx_deriving_yojson ppx_repr))
+ (libraries irmin-rpc-unix lwt unix cmdliner logs yojson ppx_deriving_yojson
+   memtrace repr ppx_repr bench_common))

--- a/bench/tree.ml
+++ b/bench/tree.ml
@@ -343,13 +343,13 @@ let main ncommits ncommits_trace operations_file quick depth width nchain_trees
   Printexc.record_backtrace true;
   Random.self_init ();
   FSHelper.rm_dir config.root;
-  (*let suite =
+  let suite =
       (* The suite contains two `Read_trace benchmarks. To prevent running both of
          them when `Quick is not set, we remove the first one (which is the head
          of the suite as well). *)
       if config.quick then List.filter (fun b -> b.speed = `Quick) suite
       else List.tl suite
-    in*)
+    in
   let run_benchmarks () =
     Lwt_list.fold_left_s
       (fun (config, results) (b : suite_elt) ->

--- a/bench/tree.ml
+++ b/bench/tree.ml
@@ -344,12 +344,12 @@ let main ncommits ncommits_trace operations_file quick depth width nchain_trees
   Random.self_init ();
   FSHelper.rm_dir config.root;
   (*let suite =
-    (* The suite contains two `Read_trace benchmarks. To prevent running both of
-       them when `Quick is not set, we remove the first one (which is the head
-       of the suite as well). *)
-    if config.quick then List.filter (fun b -> b.speed = `Quick) suite
-    else List.tl suite
-  in*)
+      (* The suite contains two `Read_trace benchmarks. To prevent running both of
+         them when `Quick is not set, we remove the first one (which is the head
+         of the suite as well). *)
+      if config.quick then List.filter (fun b -> b.speed = `Quick) suite
+      else List.tl suite
+    in*)
   let run_benchmarks () =
     Lwt_list.fold_left_s
       (fun (config, results) (b : suite_elt) ->

--- a/bench/tree.ml
+++ b/bench/tree.ml
@@ -186,7 +186,7 @@ module Benchmark = struct
       result.size
 end
 
-module Hash = Irmin.Hash.SHA1
+module Hash = Irmin.Hash.BLAKE2B
 
 module Bench_suite (Conf : sig
   val entries : int

--- a/bench/tree.ml
+++ b/bench/tree.ml
@@ -1,0 +1,430 @@
+open Bench_common
+
+let ( >>= ) = Lwt.Infix.( >>= )
+
+let ( >|= ) = Lwt.Infix.( >|= )
+
+let ( let* ) x f = Lwt.bind x f
+
+let ( let+ ) x f = Lwt.map f x
+
+type key = string list [@@deriving yojson]
+
+type hash = string [@@deriving yojson]
+
+type message = string [@@deriving yojson]
+
+type op =
+  | Add of key * string
+  | Remove of key
+  | Find of key * bool
+  | Mem of key * bool
+  | Mem_tree of key * bool
+  | Commit of hash * int64 * message * hash list
+  | Checkout of hash
+  | Copy of key * key
+[@@deriving yojson]
+
+module Parse_trace = struct
+  let read_commits commits ncommits path =
+    let json = Yojson.Safe.stream_from_file path in
+    let rec aux index_op index_commit operations =
+      if index_commit >= ncommits then index_commit
+      else
+        match Stream.next json with
+        | exception Stream.Failure ->
+            Fmt.epr
+              "Only %d commits available in the trace file, proceeding...\n%!"
+              index_commit;
+            index_commit
+        | op -> (
+            match op_of_yojson op with
+            | Ok (Commit _ as x) ->
+                commits.(index_commit) <- List.rev (x :: operations);
+                (aux [@tailcall]) (index_op + 1) (index_commit + 1) []
+            | Ok x ->
+                (aux [@tailcall]) (index_op + 1) index_commit (x :: operations)
+            | Error s -> Fmt.failwith "error op_of_yosjon %s\n%!" s)
+    in
+    aux 0 0 []
+
+  let populate_array ncommits path =
+    let commits = Array.init ncommits (fun _ -> []) in
+    let n = read_commits commits ncommits path in
+    (commits, n)
+end
+
+module Generate_trees_from_trace
+    (Store : Irmin_rpc.Client.S
+               with type contents = string
+                and type key = string list) =
+struct
+  type t = { mutable tree : Store.tree }
+
+  type stats = {
+    mutable adds : int;
+    mutable removes : int;
+    mutable finds : int;
+    mutable mems : int;
+    mutable mem_tree : int;
+    mutable copies : int;
+  }
+
+  let stats =
+    { adds = 0; removes = 0; finds = 0; mems = 0; mem_tree = 0; copies = 0 }
+
+  let get_stats () = stats
+
+  let error_find op k b n_op n_c =
+    Fmt.failwith
+      "Cannot reproduce operation %d of commit %d %s @[k = %a@] expected %b"
+      n_op n_c op
+      Fmt.(list ~sep:comma string)
+      k b
+
+  let add_operations t repo prev_commit operations n =
+    Lwt_list.fold_left_s
+      (fun (i, prev_commit) (operation : op) ->
+        match operation with
+        | Add (key, v) ->
+            stats.adds <- succ stats.adds;
+            let+ tree = Store.Tree.add t.tree key v in
+            t.tree <- tree;
+            (i + 1, prev_commit)
+        | Remove keys ->
+            stats.removes <- succ stats.removes;
+            let+ tree = Store.Tree.remove t.tree keys in
+            t.tree <- tree;
+            (i + 1, prev_commit)
+        | Find (keys, b) -> (
+            stats.finds <- succ stats.finds;
+            Store.Tree.find t.tree keys >|= function
+            | None when not b -> (i + 1, prev_commit)
+            | Some _ when b -> (i + 1, prev_commit)
+            | _ -> error_find "find" keys b i n)
+        | Mem (keys, b) ->
+            stats.mems <- succ stats.mems;
+            let+ b' = Store.Tree.mem t.tree keys in
+            if b <> b' then error_find "mem" keys b i n;
+            (i + 1, prev_commit)
+        | Mem_tree (keys, b) ->
+            stats.mem_tree <- succ stats.mem_tree;
+            let+ b' = Store.Tree.mem_tree t.tree keys in
+            if b <> b' then error_find "mem_tree" keys b i n;
+            (i + 1, prev_commit)
+        | Checkout _ ->
+            Store.Commit.of_hash repo (Option.get prev_commit) >>= fun commit ->
+            (match commit with
+            | None -> Fmt.failwith "prev commit not found"
+            | Some commit ->
+                Store.Commit.tree commit >|= fun tree -> t.tree <- tree)
+            >|= fun () -> (i + 1, prev_commit)
+        | Copy (from, to_) -> (
+            stats.copies <- succ stats.copies;
+            Store.Tree.find_tree t.tree from >>= function
+            | None -> Lwt.return (i + 1, prev_commit)
+            | Some sub_tree ->
+                let+ tree = Store.Tree.add_tree t.tree to_ sub_tree in
+                t.tree <- tree;
+                (i + 1, prev_commit))
+        | Commit (_, date, message, _) ->
+            (* in tezos commits call Tree.list first for the unshallow operation *)
+            let* _ = Store.Tree.list t.tree [] in
+            let info () = Irmin.Info.v ~date ~author:"Tezos" message in
+            let parents =
+              match prev_commit with None -> [] | Some p -> [ p ]
+            in
+            Logs.info (fun l -> l "CCC");
+            let* commit = Store.Commit.v repo ~info ~parents t.tree in
+            let* () = Store.Tree.clear t.tree in
+            let+ hash = Store.Commit.hash commit in
+            (i + 1, Some hash))
+      (0, prev_commit) operations
+
+  let add_commits repo commits () =
+    let* tree = Store.Tree.empty repo in
+    let t = { tree } in
+    let rec array_iter_lwt prev_commit i =
+      if i >= Array.length commits then Lwt.return_unit
+      else
+        let operations = commits.(i) in
+        let* _, prev_commit = add_operations t repo prev_commit operations i in
+        array_iter_lwt prev_commit (i + 1)
+    in
+    array_iter_lwt None 0
+end
+
+type config = {
+  ncommits : int;
+  ncommits_trace : int;
+  depth : int;
+  nchain_trees : int;
+  width : int;
+  nlarge_trees : int;
+  operations_file : string;
+  root : string;
+  quick : bool;
+  uri : string;
+}
+
+module Benchmark = struct
+  type result = { time : float; size : int }
+
+  let run config f =
+    let+ time, _ = with_timer f in
+    let size = FSHelper.get_size config.root in
+    { time; size }
+
+  let pp_results fmt result =
+    Format.fprintf fmt "Total time: %f@\nSize on disk: %d M" result.time
+      result.size
+end
+
+module Hash = Irmin.Hash.SHA1
+
+module Bench_suite (Conf : sig
+  val entries : int
+
+  val stable_hash : int
+end) =
+struct
+  module Store =
+    Irmin_pack.Make (Conf) (Irmin.Metadata.None) (Irmin.Contents.String)
+      (Irmin.Path.String_list)
+      (Irmin.Branch.String)
+      (Hash)
+  module Rpc =
+    Irmin_rpc_unix.Make
+      (Store)
+      (Irmin_rpc.Config.Remote.None (Store))
+      (Irmin_rpc.Config.Pack.Make (Store))
+  module Trees = Generate_trees (Rpc.Client)
+  module Trees_trace = Generate_trees_from_trace (Rpc.Client)
+
+  let init_commit repo =
+    let* tree = Rpc.Client.Tree.empty repo in
+    Logs.info (fun l -> l "AAA");
+    Rpc.Client.Commit.v repo ~info ~parents:[] tree
+
+  let checkout_and_commit repo prev_commit f =
+    let* commit = Rpc.Client.Commit.of_hash repo prev_commit in
+    match commit with
+    | None -> Lwt.fail_with "commit not found"
+    | Some commit ->
+        let* tree = Rpc.Client.Commit.tree commit in
+        let* tree = f tree in
+        Logs.info (fun l -> l "BBB");
+        Rpc.Client.Commit.v repo ~info ~parents:[ prev_commit ] tree
+
+  let add_commits repo ncommits f () : unit Lwt.t =
+    let* c = init_commit repo in
+    let rec aux c i =
+      if i >= ncommits then Lwt.return c
+      else
+        let* hash = Rpc.Client.Commit.hash c in
+        let* c' = checkout_and_commit repo hash f in
+        aux c' (i + 1)
+    in
+    let+ _ = aux c 0 in
+    ()
+
+  let run ~mode config =
+    reset_stats ();
+    let* client = Rpc.Client.connect (Uri.of_string config.uri) in
+    let* repo = Rpc.Client.repo client in
+    let+ result =
+      (match mode with
+      | `Large ->
+          Trees.add_large_trees config.width config.nlarge_trees
+          |> add_commits repo config.ncommits
+      | `Chains ->
+          Trees.add_chain_trees config.depth config.nchain_trees
+          |> add_commits repo config.ncommits)
+      |> Benchmark.run config
+    in
+    (config, result)
+end
+
+module Bench_inodes_32 = Bench_suite (Conf)
+
+module Bench_inodes_2 = Bench_suite (struct
+  let entries = 2
+
+  let stable_hash = 5
+end)
+
+type mode_elt = [ `Read_trace | `Chains | `Large ]
+
+type suite_elt = {
+  mode : mode_elt;
+  speed : [ `Quick | `Slow ];
+  inode_config : [ `Entries_32 | `Entries_2 ];
+  run : config -> (config * Benchmark.result) Lwt.t;
+}
+
+let suite : suite_elt list =
+  [
+    (*{
+        mode = `Chains;
+        speed = `Quick;
+        inode_config = `Entries_32;
+        run = Bench_inodes_32.run ~mode:`Chains;
+      };*)
+    (*{
+        mode = `Chains;
+        speed = `Slow;
+        inode_config = `Entries_2;
+        run = Bench_inodes_2.run ~mode:`Chains;
+      };*)
+    {
+      mode = `Large;
+      speed = `Quick;
+      inode_config = `Entries_32;
+      run = Bench_inodes_32.run ~mode:`Large;
+    };
+    {
+      mode = `Large;
+      speed = `Slow;
+      inode_config = `Entries_2;
+      run = Bench_inodes_2.run ~mode:`Large;
+    };
+  ]
+
+let pp_inode_config fmt = function
+  | `Entries_2 -> Format.fprintf fmt "[2, 5]"
+  | `Entries_32 -> Format.fprintf fmt "[32, 256]"
+
+let pp_config b config fmt () =
+  match b.mode with
+  | `Read_trace ->
+      let stats = Bench_inodes_32.Trees_trace.get_stats () in
+      Format.fprintf fmt
+        "Tezos_log mode on inode config %a: %d commits (%d adds; %d removes; \
+         %d finds; %d mems; %d mem_tree; %d copies)"
+        pp_inode_config b.inode_config config.ncommits_trace stats.adds
+        stats.removes stats.finds stats.mems stats.mem_tree stats.copies
+  | `Chains ->
+      Format.fprintf fmt
+        "Chain trees mode on inode config %a: %d commits, each consisting of \
+         %d chains of depth %d"
+        pp_inode_config b.inode_config config.ncommits config.nchain_trees
+        config.depth
+  | `Large ->
+      Format.fprintf fmt
+        "Large trees mode on inode config %a: %d commits, each consisting of \
+         %d large trees of %d entries"
+        pp_inode_config b.inode_config config.ncommits config.nlarge_trees
+        config.width
+
+let main ncommits ncommits_trace operations_file quick depth width nchain_trees
+    nlarge_trees uri =
+  let config =
+    {
+      ncommits;
+      ncommits_trace;
+      operations_file;
+      root = "test-rpc";
+      quick;
+      depth;
+      width;
+      nchain_trees;
+      nlarge_trees;
+      uri;
+    }
+  in
+  Printexc.record_backtrace true;
+  Random.self_init ();
+  FSHelper.rm_dir config.root;
+  let suite =
+    (* The suite contains two `Read_trace benchmarks. To prevent running both of
+       them when `Quick is not set, we remove the first one (which is the head
+       of the suite as well). *)
+    if config.quick then List.filter (fun b -> b.speed = `Quick) suite
+    else List.tl suite
+  in
+  let run_benchmarks () =
+    Lwt_list.fold_left_s
+      (fun (config, results) (b : suite_elt) ->
+        let+ config, result = b.run config in
+        (config, (b, result) :: results))
+      (config, []) suite
+  in
+  let config, results = Lwt_main.run (run_benchmarks ()) in
+  let pp_result fmt (b, result) =
+    Format.fprintf fmt "Configuration:@\n @[%a@]@\n@\nResults:@\n @[%a@]@\n"
+      (pp_config b config) () Benchmark.pp_results result
+  in
+  Fmt.pr "%a@." Fmt.(list ~sep:(any "@\n@\n") pp_result) results
+
+open Cmdliner
+
+let quick =
+  let doc = Arg.info ~doc:"Run the quick benchmarks" [ "quick" ] in
+  Arg.(value @@ flag doc)
+
+let ncommits =
+  let doc =
+    Arg.info ~doc:"Number of commits for the large and chain modes."
+      [ "n"; "ncommits" ]
+  in
+  Arg.(value @@ opt int 2 doc)
+
+let ncommits_trace =
+  let doc =
+    Arg.info ~doc:"Number of commits to read from trace." [ "ncommits_trace" ]
+  in
+  Arg.(value @@ opt int 13315 doc)
+
+let depth =
+  let doc =
+    Arg.info ~doc:"Depth of a commit's tree in chains-mode." [ "d"; "depth" ]
+  in
+  Arg.(value @@ opt int 1000 doc)
+
+let nchain_trees =
+  let doc =
+    Arg.info ~doc:"Number of chain trees per commit in chains-mode."
+      [ "c"; "nchain" ]
+  in
+  Arg.(value @@ opt int 1 doc)
+
+let width =
+  let doc =
+    Arg.info ~doc:"Width of a commit's tree in large-mode." [ "w"; "width" ]
+  in
+  Arg.(value @@ opt int 1000000 doc)
+
+let nlarge_trees =
+  let doc =
+    Arg.info ~doc:"Number of large trees per commit in large-mode."
+      [ "l"; "nlarge" ]
+  in
+  Arg.(value @@ opt int 1 doc)
+
+let operations_file =
+  let doc =
+    Arg.info ~doc:"Compressed file containing the tree operations."
+      [ "f"; "file" ]
+  in
+  Arg.(value @@ opt string "bench/irmin-pack/tezos_log.tar.gz" doc)
+
+let uri =
+  let doc = Arg.info ~doc:"Cap'n'proto URL" [] in
+  Arg.(value @@ pos 0 string "" doc)
+
+let main_term =
+  Term.(
+    const main
+    $ ncommits
+    $ ncommits_trace
+    $ operations_file
+    $ quick
+    $ depth
+    $ width
+    $ nchain_trees
+    $ nlarge_trees
+    $ uri)
+
+let () =
+  let info = Term.info "Benchmarks for tree operations" in
+  Term.exit @@ Term.eval (main_term, info)

--- a/bench/tree.ml
+++ b/bench/tree.ml
@@ -209,7 +209,7 @@ struct
 
   let init_commit repo =
     let* tree = Rpc.Client.Tree.empty repo in
-    Logs.info (fun l -> l "AAA");
+    Logs.info (fun l -> l "init_commit");
     Rpc.Client.Commit.v repo ~info ~parents:[] tree
 
   let checkout_and_commit repo prev_commit f =
@@ -221,7 +221,7 @@ struct
         let* tx = Rpc.Client.Tx.v repo tree in
         let* tx = f tx in
         let* tree = Rpc.Client.Tx.tree tx in
-        Logs.info (fun l -> l "BBB");
+        Logs.info (fun l -> l "Checkout_and_commit");
         Rpc.Client.Commit.v repo ~info ~parents:[ prev_commit ] tree
 
   let add_commits repo ncommits f () : unit Lwt.t =

--- a/bench/tree.ml
+++ b/bench/tree.ml
@@ -286,7 +286,7 @@ let suite : suite_elt list =
       };*)
     {
       mode = `Large;
-      speed = `Quick;
+      speed = `Slow;
       inode_config = `Entries_32;
       run = Bench_inodes_32.run ~mode:`Large;
     };

--- a/bench/tree.ml
+++ b/bench/tree.ml
@@ -286,7 +286,7 @@ let suite : suite_elt list =
       };*)
     {
       mode = `Large;
-      speed = `Slow;
+      speed = `Quick;
       inode_config = `Entries_32;
       run = Bench_inodes_32.run ~mode:`Large;
     };

--- a/bench/tree.ml
+++ b/bench/tree.ml
@@ -218,9 +218,9 @@ struct
     | None -> Lwt.fail_with "commit not found"
     | Some commit ->
         let* tree = Rpc.Client.Commit.tree commit in
-        let* tx = Rpc.Client.Tx.v repo tree in
+        let* tx = Rpc.Client.Tree.Local.of_tree repo tree in
         let* tx = f tx in
-        let* tree = Rpc.Client.Tx.tree tx in
+        let* tree = Rpc.Client.Tree.Local.to_tree repo tx in
         Logs.info (fun l -> l "Checkout_and_commit");
         Rpc.Client.Commit.v repo ~info ~parents:[ prev_commit ] tree
 

--- a/bench/tree.ml
+++ b/bench/tree.ml
@@ -343,13 +343,13 @@ let main ncommits ncommits_trace operations_file quick depth width nchain_trees
   Printexc.record_backtrace true;
   Random.self_init ();
   FSHelper.rm_dir config.root;
-  let suite =
+  (*let suite =
     (* The suite contains two `Read_trace benchmarks. To prevent running both of
        them when `Quick is not set, we remove the first one (which is the head
        of the suite as well). *)
     if config.quick then List.filter (fun b -> b.speed = `Quick) suite
     else List.tl suite
-  in
+  in*)
   let run_benchmarks () =
     Lwt_list.fold_left_s
       (fun (config, results) (b : suite_elt) ->

--- a/examples/client.ml
+++ b/examples/client.ml
@@ -28,7 +28,7 @@ let main =
   let* tree = Client.Store.find_tree master [ "abc" ] in
   let* concrete =
     match tree with
-    | Some c -> Client.Tree.concrete c >>= Lwt.return_some
+    | Some c -> Client.Tree.to_concrete c >>= Lwt.return_some
     | None -> Lwt.return_none
   in
   assert (match concrete with Some (`Contents _) -> true | _ -> false);

--- a/examples/common.ml
+++ b/examples/common.ml
@@ -9,7 +9,7 @@ module Store =
     (Irmin.Contents.String)
     (Irmin.Path.String_list)
     (Irmin.Branch.String)
-    (Irmin.Hash.BLAKE2B)
+    (Irmin.Hash.SHA1)
 
 module Rpc =
   Irmin_rpc_unix.Make

--- a/examples/common.ml
+++ b/examples/common.ml
@@ -3,7 +3,7 @@ module Store =
     (struct
       let stable_hash = 32
 
-      let entries = 32
+      let entries = 256
     end)
     (Irmin.Metadata.None)
     (Irmin.Contents.String)

--- a/examples/common.ml
+++ b/examples/common.ml
@@ -1,9 +1,9 @@
 module Store =
   Irmin_pack.Make
     (struct
-      let stable_hash = 32
+      let stable_hash = 256
 
-      let entries = 256
+      let entries = 32
     end)
     (Irmin.Metadata.None)
     (Irmin.Contents.String)

--- a/examples/dune
+++ b/examples/dune
@@ -1,5 +1,5 @@
 (executables
- (names client server tree)
+ (names client server tree ping)
  (libraries checkseum.c digestif.c irmin-unix irmin-rpc-unix lwt lwt.unix uri
    capnp-rpc-unix))
 

--- a/examples/dune
+++ b/examples/dune
@@ -1,5 +1,5 @@
 (executables
- (names client server tree tree2)
+ (names client server tree)
  (libraries checkseum.c digestif.c irmin-unix irmin-rpc-unix lwt lwt.unix uri
    capnp-rpc-unix))
 

--- a/examples/dune
+++ b/examples/dune
@@ -1,5 +1,5 @@
 (executables
- (names client server tree)
+ (names client server tree tree2)
  (libraries checkseum.c digestif.c irmin-unix irmin-rpc-unix lwt lwt.unix uri
    capnp-rpc-unix))
 

--- a/examples/ping.ml
+++ b/examples/ping.ml
@@ -1,0 +1,20 @@
+open Lwt.Syntax
+open Common
+module Client = Rpc.Client
+
+let () =
+  Logs.set_level (Some Logs.Info);
+  Logs.set_reporter (Logs_fmt.reporter ())
+
+(* This was printed when running the server example
+ * Something like: "capnp://sha-256:QZVBfR2-8g6nfK7cRrD763Usn5Fg0j2muRXk62BhYKI@127.0.0.1:9998/yGlvMAKwxOw4B3lYe0g9XCuV4o5cp9BOQENvSvZNpjU" *)
+let uri = Sys.argv.(1)
+
+let ( let* ) = Lwt.bind
+
+let main =
+  let* client = Uri.of_string uri |> Client.connect in
+  let+ x = Client.ping client in
+  Result.get_ok x
+
+let () = Lwt_main.run main

--- a/examples/tree.ml
+++ b/examples/tree.ml
@@ -19,9 +19,11 @@ let main =
   let* repo = Client.repo client in
   let* master = Client.Store.master repo in
   let* tree = Client.Tree.empty repo in
-  let* tree = Client.Tree.add tree [ "a" ] "1" in
-  let* tree = Client.Tree.add tree [ "x"; "y"; "z" ] "999" in
+  let* tx = Client.Tx.v repo tree in
+  let* () = Client.Tx.add tx [ "a" ] "1" in
+  let* () = Client.Tx.add tx [ "x"; "y"; "z" ] "999" in
 
+  let* tree = Client.Tx.tree tx in
   let* a = Client.Tree.find tree [ "a" ] in
   assert (Option.get a = "1");
   let* xyz = Client.Tree.find tree [ "x"; "y"; "z" ] in
@@ -30,8 +32,8 @@ let main =
   let* z = Client.Tree.find (Option.get t) [ "z" ] in
   assert (Option.get z = "999");
 
-  let* tree = Client.Tree.remove tree [ "a" ] in
-
+  let* () = Client.Tx.remove tx [ "a" ] in
+  let* tree = Client.Tx.tree tx in
   let* () = Client.Store.set_tree master ~info [] tree in
   let* a = Client.Store.find master [ "a" ] in
   assert (Result.get_ok a = None);

--- a/examples/tree.ml
+++ b/examples/tree.ml
@@ -33,8 +33,7 @@ let main =
   assert (Option.get z = "999");
 
   let* () = Client.Tx.remove tx [ "a" ] in
-  let* tree = Client.Tx.tree tx in
-  let* () = Client.Store.set_tree master ~info [] tree in
+  let* () = Client.Tx.commit tx master ~info [] in
   let* a = Client.Store.find master [ "a" ] in
   assert (Result.get_ok a = None);
   let* xyz = Client.Store.get master [ "x"; "y"; "z" ] in

--- a/examples/tree.ml
+++ b/examples/tree.ml
@@ -33,6 +33,7 @@ let main =
   assert (Option.get z = "999");
 
   let* () = Client.Tx.remove tx [ "a" ] in
+
   let* () = Client.Tx.commit tx master ~info [] in
   let* a = Client.Store.find master [ "a" ] in
   assert (Result.get_ok a = None);

--- a/irmin-rpc-mirage.opam
+++ b/irmin-rpc-mirage.opam
@@ -11,11 +11,11 @@ depends: [
   "dune" {>= "2.0.0"}
   "irmin-rpc"
   "irmin-mirage" {>= "dev"}
+  "irmin-mirage-git" {>= "dev"}
   "mirage-time" {>= "2.0.0"}
   "mirage-stack" {>= "2.0.0"}
   "dns-client"
   "capnp-rpc-mirage" {>= "0.9.0"}
-  "git-mirage"
   "capnp-rpc-lwt" {>= "0.9.0"}
   "capnp-rpc-net" {>= "0.9.0"}
   "irmin" {>= "dev"}

--- a/irmin-rpc-mirage.opam
+++ b/irmin-rpc-mirage.opam
@@ -36,4 +36,5 @@ pin-depends: [
   ["ppx_irmin.dev" "git+https://github.com/mirage/irmin#806315563437cb8d77e32f75daee1408f32b2bda"]
   ["irmin.dev" "git+https://github.com/mirage/irmin#806315563437cb8d77e32f75daee1408f32b2bda"]
   ["irmin-mirage.dev" "git+https://github.com/mirage/irmin#806315563437cb8d77e32f75daee1408f32b2bda"]
+  ["irmin-mirage-git.dev" "git+https://github.com/mirage/irmin#806315563437cb8d77e32f75daee1408f32b2bda"]
 ]

--- a/src/irmin-rpc-mirage/dune
+++ b/src/irmin-rpc-mirage/dune
@@ -1,6 +1,6 @@
 (library
  (name irmin_rpc_mirage)
  (public_name irmin-rpc-mirage)
- (libraries irmin irmin-rpc capnp-rpc-mirage capnp-rpc-net
-   capnp-rpc-lwt irmin-mirage-git mirage-time dns-client dns-client.mirage
+ (libraries irmin irmin-mirage-git irmin-rpc capnp-rpc-mirage capnp-rpc-net
+   capnp-rpc-lwt  mirage-time dns-client dns-client.mirage
    mirage-random mirage-clock mirage-stack lwt uri))

--- a/src/irmin-rpc-mirage/dune
+++ b/src/irmin-rpc-mirage/dune
@@ -1,6 +1,6 @@
 (library
  (name irmin_rpc_mirage)
  (public_name irmin-rpc-mirage)
- (libraries irmin irmin-rpc git-mirage capnp-rpc-mirage capnp-rpc-net
-   capnp-rpc-lwt irmin-mirage mirage-time dns-client dns-client.mirage
+ (libraries irmin irmin-rpc capnp-rpc-mirage capnp-rpc-net
+   capnp-rpc-lwt irmin-mirage-git mirage-time dns-client dns-client.mirage
    mirage-random mirage-clock mirage-stack lwt uri))

--- a/src/irmin-rpc-mirage/dune
+++ b/src/irmin-rpc-mirage/dune
@@ -2,5 +2,5 @@
  (name irmin_rpc_mirage)
  (public_name irmin-rpc-mirage)
  (libraries irmin irmin-mirage-git irmin-rpc capnp-rpc-mirage capnp-rpc-net
-   capnp-rpc-lwt  mirage-time dns-client dns-client.mirage
-   mirage-random mirage-clock mirage-stack lwt uri))
+   capnp-rpc-lwt mirage-time dns-client dns-client.mirage mirage-random
+   mirage-clock mirage-stack lwt uri))

--- a/src/irmin-rpc-mirage/irmin_rpc_mirage.mli
+++ b/src/irmin-rpc-mirage/irmin_rpc_mirage.mli
@@ -18,6 +18,7 @@ module Make
          and type hash = Store.hash
 
     val serve :
+      ?max_tx:int ->
       secret_key:[< `PEM of string | `Ephemeral ] ->
       ?switch:Lwt_switch.t ->
       ?serve_tls:bool ->

--- a/src/irmin-rpc-mirage/irmin_rpc_mirage.mli
+++ b/src/irmin-rpc-mirage/irmin_rpc_mirage.mli
@@ -33,11 +33,14 @@ module Make
       Irmin_rpc.Client.S
         with type branch = Store.branch
          and type key = Store.key
-         and type step = Store.Key.step
          and type contents = Store.contents
          and type hash = Store.hash
+         and type Sync.endpoint = Remote.t
+         and type step = Store.Key.step
          and module Key = Store.Key
          and module Hash = Store.Hash
+         and type metadata = Store.metadata
+         and type Tree.Local.t = Store.tree
 
     val connect : Stack.t -> Uri.t -> t Lwt.t
   end

--- a/src/irmin-rpc-unix/bin/main.ml
+++ b/src/irmin-rpc-unix/bin/main.ml
@@ -37,6 +37,7 @@ let run (Irmin_unix.Resolver.S ((module Store), store, _)) host port secret_key
       | None ->
           Logs.app (fun l -> l "%s" (Uri.to_string (Rpc.Server.uri server)))
     in
+
     let http =
       Cohttp_lwt_unix.Server.make
         ~callback:(http_server (module Store) (Store.repo store))

--- a/src/irmin-rpc-unix/bin/main.ml
+++ b/src/irmin-rpc-unix/bin/main.ml
@@ -6,7 +6,6 @@ let () =
   Logs.set_reporter (Logs_fmt.reporter ())
 
 let config path =
-  print_endline path;
   let head = Git.Reference.of_string "refs/heads/master" |> Result.get_ok in
   Irmin_git.config ~head path
 
@@ -33,8 +32,7 @@ let run (Irmin_unix.Resolver.S ((module Store), store, _)) host port secret_key
           output_string f (Uri.to_string (Rpc.Server.uri server));
           close_out f
       | None ->
-          Printf.printf "Serving on: %s\n%!"
-            (Uri.to_string (Rpc.Server.uri server))
+          Logs.app (fun l -> l "%s" (Uri.to_string (Rpc.Server.uri server)))
     in
     fst (Lwt.wait ())
   in

--- a/src/irmin-rpc-unix/bin/main.ml
+++ b/src/irmin-rpc-unix/bin/main.ml
@@ -2,7 +2,7 @@ open Cmdliner
 open Lwt.Infix
 
 let () =
-  Logs.set_level (Some Logs.Info);
+  Logs.set_level (Some Logs.App);
   Logs.set_reporter (Logs_fmt.reporter ())
 
 let config path =

--- a/src/irmin-rpc-unix/irmin_rpc_unix.ml
+++ b/src/irmin-rpc-unix/irmin_rpc_unix.ml
@@ -23,7 +23,7 @@ struct
 
     let uri { uri; _ } = uri
 
-    let serve ?backlog ?switch ?secure:serve_tls ~secret_key addr repo =
+    let serve ?max_tx ?backlog ?switch ?secure:serve_tls ~secret_key addr repo =
       let config =
         Capnp_rpc_unix.Vat_config.create ?backlog ~secret_key ?serve_tls addr
       in
@@ -32,7 +32,8 @@ struct
         | Some true | None -> Capnp_rpc_unix.Vat_config.derived_id config "main"
         | Some false -> Capnp_rpc_net.Restorer.Id.public ""
       in
-      let restore = Capnp_rpc_net.Restorer.single service_id (Api.local repo) in
+      let ctx = Api.ctx ?max_tx repo in
+      let restore = Capnp_rpc_net.Restorer.single service_id (Api.local ctx) in
       Capnp_rpc_unix.serve ?switch ~restore config >|= fun vat ->
       { uri = Capnp_rpc_unix.Vat.sturdy_uri vat service_id }
   end

--- a/src/irmin-rpc-unix/irmin_rpc_unix.mli
+++ b/src/irmin-rpc-unix/irmin_rpc_unix.mli
@@ -37,12 +37,16 @@ module Make
   module Client : sig
     include
       Irmin_rpc.Client.S
-        with type key = Store.key
-         and type step = Store.Key.step
-         and type hash = Store.hash
-         and type branch = Store.branch
+        with type branch = Store.branch
+         and type key = Store.key
          and type contents = Store.contents
+         and type hash = Store.hash
+         and type Sync.endpoint = Remote.t
+         and type step = Store.Key.step
+         and module Key = Store.Key
+         and module Hash = Store.Hash
          and type metadata = Store.metadata
+         and type Tree.Local.t = Store.tree
 
     val connect : Uri.t -> t Lwt.t
   end

--- a/src/irmin-rpc-unix/irmin_rpc_unix.mli
+++ b/src/irmin-rpc-unix/irmin_rpc_unix.mli
@@ -42,6 +42,7 @@ module Make
          and type hash = Store.hash
          and type branch = Store.branch
          and type contents = Store.contents
+         and type metadata = Store.metadata
 
     val connect : Uri.t -> t Lwt.t
   end

--- a/src/irmin-rpc-unix/irmin_rpc_unix.mli
+++ b/src/irmin-rpc-unix/irmin_rpc_unix.mli
@@ -13,6 +13,7 @@ module Make
     val uri : t -> Uri.t
 
     val serve :
+      ?max_tx:int ->
       ?backlog:int ->
       ?switch:Lwt_switch.t ->
       ?secure:bool ->

--- a/src/irmin-rpc/client.ml
+++ b/src/irmin-rpc/client.ml
@@ -315,7 +315,7 @@ functor
         let req = Capability.Request.create_no_args () in
         let+ x =
           Capability.with_ref tree (fun tree ->
-          Capability.call_for_value_exn tree method_id req)
+              Capability.call_for_value_exn tree method_id req)
         in
         let concrete = Results.concrete_get x in
         Codec.Tree.decode concrete
@@ -348,6 +348,14 @@ functor
         let+ res = Capability.call_for_value_exn t method_id req in
         let l = Results.items_get_list res in
         List.map (fun x -> Codec.Key.Step.decode x |> unwrap) l
+
+      let equal a b =
+        let open Raw.Client.Tree.Equal in
+        Logs.info (fun l -> l "Tree.equal");
+        let req, p = Capability.Request.create Params.init_pointer in
+        Params.other_set p (Some b);
+        let+ res = Capability.call_for_value_exn a method_id req in
+        Results.equal_get res
 
       module Local = struct
         type t = St.tree

--- a/src/irmin-rpc/client.ml
+++ b/src/irmin-rpc/client.ml
@@ -316,6 +316,15 @@ functor
         (*Capability.with_ref tx (fun tx ->*)
         Capability.call_for_unit_exn tx method_id req
 
+      let add_contents tx key value =
+        let open Raw.Client.Tx.AddContents in
+        (*Logs.info (fun l -> l "Tx.add");*)
+        let req, p = Capability.Request.create Params.init_pointer in
+        Params.key_set p (Codec.Key.encode key);
+        Params.hash_set p (Codec.Hash.encode value);
+        (*Capability.with_ref tx (fun tx ->*)
+        Capability.call_for_unit_exn tx method_id req
+
       let add_tree tx key value =
         let open Raw.Client.Tx.AddTree in
         Logs.info (fun l -> l "Tx.add_tree");
@@ -439,8 +448,8 @@ functor
           info () |> Codec.Info.encode |> Params.info_set_builder p
         in
         Codec.Contents.encode contents |> Params.contents_set p;
-        Capability.with_ref t (fun t ->
-            Capability.call_for_unit_exn t method_id req)
+        (*Capability.with_ref t (fun t ->*)
+        Capability.call_for_unit_exn t method_id req
 
       let test_and_set ~info t key ~test ~set =
         let open Raw.Client.Store.TestAndSet in
@@ -469,8 +478,8 @@ functor
             let (_ : Raw.Builder.Info.t) =
               info () |> Codec.Info.encode |> Params.info_set_builder p
             in
-            Capability.with_ref t (fun t ->
-                Capability.call_for_unit_exn t method_id req))
+            (*Capability.with_ref t (fun t ->*)
+            Capability.call_for_unit_exn t method_id req)
 
       let test_and_set_tree ~info t key ~test ~set =
         let open Raw.Client.Store.TestAndSetTree in
@@ -668,9 +677,6 @@ functor
       let open Raw.Client.Irmin.Ping in
       Logs.info (fun l -> l "Irmin.ping");
       let req = Capability.Request.create_no_args () in
-      let+ res =
-        Capability.with_ref t (fun t ->
-            Capability.call_for_value t method_id req)
-      in
+      let+ res = Capability.call_for_value t method_id req in
       Result.map (fun _ -> ()) res
   end

--- a/src/irmin-rpc/client_intf.ml
+++ b/src/irmin-rpc/client_intf.ml
@@ -211,6 +211,9 @@ module type S = sig
     val concrete : tree -> concrete Lwt.t
     (** Return a concrete representation of a tree *)
 
+    val of_concrete : repo -> concrete -> tree Lwt.t
+    (** Create a remote tree from a [concrete] tree *)
+
     val find_hash : tree -> key -> hash option Lwt.t
     (** Get hash of contents at the given key *)
 
@@ -224,6 +227,9 @@ module type S = sig
 
   module Contents : sig
     include Irmin.Contents.S with type t = contents
+
+    val import : repo -> contents list -> hash list Lwt.t
+    (** import contents to the repo, returning a hash for each item *)
 
     val of_hash : repo -> hash -> contents option Lwt.t
     (** Get hash from contents, this function uses caching to avoid calling to

--- a/src/irmin-rpc/client_intf.ml
+++ b/src/irmin-rpc/client_intf.ml
@@ -14,6 +14,8 @@ module Types = struct
   type pack = Raw.Client.Pack.t Capability.t
 
   type tree = Raw.Client.Tree.t Capability.t
+
+  type tx = Raw.Client.Tx.t Capability.t
 end
 
 module type S = sig
@@ -196,12 +198,6 @@ module type S = sig
     val get_tree : t -> key -> tree Lwt.t
     (** Get a subtree *)
 
-    val add : tree -> key -> contents -> tree Lwt.t
-    (** Add new key/value to tree *)
-
-    val add_tree : tree -> key -> tree -> tree Lwt.t
-    (** Add subtree *)
-
     val mem : tree -> key -> bool Lwt.t
     (** Check if contents exist at the given key *)
 
@@ -217,12 +213,26 @@ module type S = sig
     val find_hash : tree -> key -> hash option Lwt.t
     (** Get hash of contents at the given key *)
 
-    val remove : tree -> key -> tree Lwt.t
-    (** Remove a key from an existing tree *)
-
     val list : tree -> key -> step list Lwt.t
+  end
 
-    val clear : tree -> unit Lwt.t
+  module Tx : sig
+    type t = tx
+
+    val v : repo -> tree -> tx Lwt.t
+    (** Convert a [Tree] into an editable [Tx] *)
+
+    val remove : tx -> key -> unit Lwt.t
+    (** Remove a key from [Tx] *)
+
+    val add : tx -> key -> contents -> unit Lwt.t
+    (** Add new key/value to [Tx] *)
+
+    val add_tree : tx -> key -> tree -> unit Lwt.t
+    (** Add subtree *)
+
+    val tree : tx -> tree Lwt.t
+    (** Get [Tree] from [Tx] *)
   end
 
   module Contents : sig

--- a/src/irmin-rpc/client_intf.ml
+++ b/src/irmin-rpc/client_intf.ml
@@ -113,6 +113,9 @@ module type S = sig
   module Branch : sig
     include Irmin.Branch.S with type t = branch
 
+    val get : repo -> branch -> commit Lwt.t
+    (** Get branch head *)
+
     val list : repo -> branch list Lwt.t
     (** List all branches *)
 
@@ -240,6 +243,9 @@ module type S = sig
 
     val commit : tx -> store -> info:Irmin.Info.f -> key -> unit Lwt.t
     (** Commit transaction *)
+
+    val abort : tx -> unit
+    (** Abort transaction *)
   end
 
   module Contents : sig

--- a/src/irmin-rpc/client_intf.ml
+++ b/src/irmin-rpc/client_intf.ml
@@ -104,7 +104,7 @@ module type S = sig
     val pack : t -> pack option Lwt.t
     (** Get [pack] capability *)
 
-    val last_modified : t -> key -> commit Lwt.t
+    val last_modified : t -> key -> commit option Lwt.t
     (** Returns the last commit containing changes to the specified key *)
   end
 
@@ -124,9 +124,11 @@ module type S = sig
   module Commit : sig
     type t = commit
 
+    val v : repo -> info:Irmin.Info.f -> parents:hash list -> tree -> t Lwt.t
+
     val check : commit -> bool Lwt.t
 
-    val of_hash : repo -> hash -> commit Lwt.t
+    val of_hash : repo -> hash -> commit option Lwt.t
     (** Get commit from specified hash *)
 
     val hash : commit -> hash Lwt.t
@@ -214,6 +216,10 @@ module type S = sig
 
     val remove : tree -> key -> tree Lwt.t
     (** Remove a key from an existing tree *)
+
+    val list : tree -> key -> step list Lwt.t
+
+    val clear : tree -> unit Lwt.t
   end
 
   module Contents : sig

--- a/src/irmin-rpc/client_intf.ml
+++ b/src/irmin-rpc/client_intf.ml
@@ -221,6 +221,8 @@ module type S = sig
 
     val list : tree -> key -> step list Lwt.t
 
+    val equal : tree -> tree -> bool Lwt.t
+
     module Local : sig
       type t
 

--- a/src/irmin-rpc/client_intf.ml
+++ b/src/irmin-rpc/client_intf.ml
@@ -327,6 +327,7 @@ module type MAKER = functor
      and module Key = Store.Key
      and module Hash = Store.Hash
      and type metadata = Store.metadata
+     and type Tree.Local.t = Store.tree
 
 module type Client = sig
   module type S = S

--- a/src/irmin-rpc/client_intf.ml
+++ b/src/irmin-rpc/client_intf.ml
@@ -237,6 +237,9 @@ module type S = sig
 
     val tree : tx -> tree Lwt.t
     (** Get [Tree] from [Tx] *)
+
+    val commit : tx -> store -> info:Irmin.Info.f -> key -> unit Lwt.t
+    (** Commit transaction *)
   end
 
   module Contents : sig

--- a/src/irmin-rpc/client_intf.ml
+++ b/src/irmin-rpc/client_intf.ml
@@ -228,6 +228,10 @@ module type S = sig
     val add : tx -> key -> contents -> unit Lwt.t
     (** Add new key/value to [Tx] *)
 
+    val add_contents : tx -> key -> hash -> unit Lwt.t
+    (** Add new key/value to [Tx] using the contents hash instead of the direct
+        value *)
+
     val add_tree : tx -> key -> tree -> unit Lwt.t
     (** Add subtree *)
 

--- a/src/irmin-rpc/client_intf.ml
+++ b/src/irmin-rpc/client_intf.ml
@@ -270,6 +270,9 @@ module type S = sig
     val v : repo -> tree -> tx Lwt.t
     (** Convert a [Tree] into an editable [Tx] *)
 
+    val empty : repo -> tx Lwt.t
+    (** Create a new transaction with an empty tree *)
+
     val remove : tx -> key -> unit Lwt.t
     (** Remove a key from [Tx] *)
 

--- a/src/irmin-rpc/codec.ml
+++ b/src/irmin-rpc/codec.ml
@@ -8,9 +8,9 @@ let unwrap = function Ok x -> x | Error (`Msg m) -> raise (Error_message m)
 let errorf fmt = Format.kasprintf (fun m -> Error (`Msg m)) fmt
 
 let codec_of_type (type a) (t : a Irmin.Type.t) =
-  let encode = Irmin.Type.to_string t
+  let encode = Irmin.Type.(unstage (to_bin_string t))
   and decode s =
-    (Irmin.Type.of_string t s
+    (Irmin.Type.(unstage (of_bin_string t)) s
       : (a, [ `Msg of _ ]) result
       :> (a, [> `Msg of _ ]) result)
   in

--- a/src/irmin-rpc/irmin_api.capnp
+++ b/src/irmin-rpc/irmin_api.capnp
@@ -219,7 +219,6 @@ interface Repo {
   # Convert a concrete tree to `Tree`
   treeOfConcrete @10 (concrete :Tree.Concrete) -> (tree :Tree);
 
-
   tx @11 (tree :Tree) -> (tx :Tx);
 }
 

--- a/src/irmin-rpc/irmin_api.capnp
+++ b/src/irmin-rpc/irmin_api.capnp
@@ -39,36 +39,39 @@ interface Tree {
   # Get the tree with a root at `key`
   findTree @1 (key :Key) -> (tree :Tree);
 
-  # Add a value
-  add @2 (key :Key, contents :Contents) -> (tree :Tree);
-
-  # Add a tree
-  addTree @3 (key :Key, tree :Tree) -> (tree :Tree);
-
   # Check if there is a value associated with `key`
-  mem @4 (key :Key) -> (exists :Bool);
+  mem @2 (key :Key) -> (exists :Bool);
 
   # Check if there is a tree associated with `key`
-  memTree @5 (key :Key) -> (exists :Bool);
+  memTree @3 (key :Key) -> (exists :Bool);
 
   # Get a concrete representation of an Irmin tree
-  getConcrete @6 () -> (concrete :Concrete);
+  getConcrete @4 () -> (concrete :Concrete);
 
   # Get tree hash
-  hash @7 () -> (hash :Hash);
+  hash @5 () -> (hash :Hash);
 
   # Find hash for value associated with `key`
-  findHash @8 (key :Key) -> (hash :Hash);
+  findHash @6 (key :Key) -> (hash :Hash);
 
-  # Remove a value from the tree
-  remove   @9  (key :Key) -> (tree :Tree);
-
-  list @10 (key :Key) -> (items :List(Step));
+  list @7 (key :Key) -> (items :List(Step));
 
   # Check if tree exists
-  check       @11 () -> (bool :Bool);
+  check       @8 () -> (bool :Bool);
+}
 
-  clear       @12 () -> ();
+# Writeable trees
+interface Tx {
+  # Add a value
+  add @0 (key :Key, contents :Contents) -> ();
+
+  # Add a tree
+  addTree @1 (key :Key, tree :Tree) -> ();
+
+  # Remove a value from the tree
+  remove   @2  (key :Key) -> ();
+
+  tree @3 () -> (tree :Tree);
 }
 
 interface Commit {
@@ -213,6 +216,9 @@ interface Repo {
 
   # Convert a concrete tree to `Tree`
   treeOfConcrete @10 (concrete :Tree.Concrete) -> (tree :Tree);
+
+
+  tx @11 (tree :Tree) -> (tx :Tx);
 }
 
 # The top-level interface of an RPC server

--- a/src/irmin-rpc/irmin_api.capnp
+++ b/src/irmin-rpc/irmin_api.capnp
@@ -7,6 +7,7 @@ using Hash = Data;
 using Contents = Data;
 using Endpoint = Data;
 using Key = Text;
+using Step = Text;
 
 # Irmin.info
 struct Info {
@@ -62,10 +63,12 @@ interface Tree {
   # Remove a value from the tree
   remove   @9  (key :Key) -> (tree :Tree);
 
-  listKeys @10 (key :Key) -> (keys :List(Key));
+  list @10 (key :Key) -> (items :List(Step));
 
   # Check if tree exists
   check       @11 () -> (bool :Bool);
+
+  clear       @12 () -> ();
 }
 
 interface Commit {
@@ -201,6 +204,9 @@ interface Repo {
 
   # Create an empty tree
   emptyTree @7 () -> (tree :Tree);
+
+  # Create commit
+  createCommit @8 (info :Info, parents :List(Hash), tree :Tree) -> (commit :Commit);
 }
 
 # The top-level interface of an RPC server

--- a/src/irmin-rpc/irmin_api.capnp
+++ b/src/irmin-rpc/irmin_api.capnp
@@ -72,6 +72,8 @@ interface Tx {
   remove   @2  (key :Key) -> ();
 
   tree @3 () -> (tree :Tree);
+
+  addContents @4 (key :Key, hash :Hash) -> ();
 }
 
 interface Commit {

--- a/src/irmin-rpc/irmin_api.capnp
+++ b/src/irmin-rpc/irmin_api.capnp
@@ -59,6 +59,8 @@ interface Tree {
 
   # Check if tree exists
   check       @8 () -> (bool :Bool);
+
+  equal @9 (other :Tree) -> (equal :Bool);
 }
 
 # Writeable trees

--- a/src/irmin-rpc/irmin_api.capnp
+++ b/src/irmin-rpc/irmin_api.capnp
@@ -8,6 +8,7 @@ using Contents = Data;
 using Endpoint = Data;
 using Key = Data;
 using Step = Data;
+using Branch = Text;
 
 # Irmin.info
 struct Info {
@@ -193,13 +194,13 @@ interface Repo {
   ofBranch  @1  (branch :Text) -> (store :Store);
 
   # List all branches
-  branchList    @2  () -> (branches :List(Text));
+  branchList    @2  () -> (branches :List(Branch));
 
   # Remove a branch
-  branchRemove  @3  (branch :Text) -> ();
+  branchRemove  @3  (branch :Branch) -> ();
 
   # Create a new branch using the given branch name and `commit`
-  branchSet     @4  (branch :Text, commit :Commit) -> ();
+  branchSet     @4  (branch :Branch, commit :Commit) -> ();
 
   # Find commit for `hash`
   commitOfHash   @5  (hash :Hash) -> (commit :Commit);
@@ -220,6 +221,8 @@ interface Repo {
   treeOfConcrete @10 (concrete :Tree.Concrete) -> (tree :Tree);
 
   tx @11 (tree :Tree) -> (tx :Tx);
+
+  branchHead @12 (branch :Branch) -> (commit :Commit);
 }
 
 # The top-level interface of an RPC server

--- a/src/irmin-rpc/irmin_api.capnp
+++ b/src/irmin-rpc/irmin_api.capnp
@@ -6,8 +6,8 @@ using Hash = Data;
 # Store.contents
 using Contents = Data;
 using Endpoint = Data;
-using Key = Text;
-using Step = Text;
+using Key = Data;
+using Step = Data;
 
 # Irmin.info
 struct Info {
@@ -20,7 +20,7 @@ struct Info {
 # Store.Tree
 interface Tree {
   struct Node {
-    step  @0  :Text;
+    step  @0  :Step;
     tree  @1  :Concrete;
   }
 
@@ -207,6 +207,12 @@ interface Repo {
 
   # Create commit
   createCommit @8 (info :Info, parents :List(Hash), tree :Tree) -> (commit :Commit);
+
+  # Add contents and return hash
+  importContents @9 (values :List(Contents)) -> (hash :List(Hash));
+
+  # Convert a concrete tree to `Tree`
+  treeOfConcrete @10 (concrete :Tree.Concrete) -> (tree :Tree);
 }
 
 # The top-level interface of an RPC server

--- a/src/irmin-rpc/server.ml
+++ b/src/irmin-rpc/server.ml
@@ -923,7 +923,6 @@ functor
             with_initialised_results
               (module Results)
               (fun results ->
-                Logs.info (fun l -> l "XXX");
                 let parents =
                   List.map (fun x -> Codec.Hash.decode x |> unwrap) parents
                 in
@@ -1005,6 +1004,7 @@ functor
                 in
                 let cap = Commit.local repo branch in
                 Results.commit_set results (Some cap);
+                Capability.dec_ref cap;
                 Ok ())
         end
         |> Repo.local

--- a/src/irmin-rpc/server.ml
+++ b/src/irmin-rpc/server.ml
@@ -215,6 +215,19 @@ functor
               (fun results ->
                 Results.bool_set results true;
                 Lwt.return_ok ())
+
+          method equal_impl params release_param_caps =
+            let open Tree.Equal in
+            let other = Params.other_get params in
+            release_param_caps ();
+            Logs.info (fun f -> f "Tree.equal");
+            with_initialised_results
+              (module Results)
+              (fun results ->
+                let other = Hashtbl.find trees (Option.get other) in
+                let q = Irmin.Type.(unstage @@ equal St.tree_t) tree other in
+                Results.equal_set results q;
+                Lwt.return_ok ())
         end
         |> Tree.local
 

--- a/src/irmin-rpc/server.ml
+++ b/src/irmin-rpc/server.ml
@@ -314,13 +314,19 @@ functor
         end
         |> Tx.local
 
+      and tx_limit = 32
+
       and local client repo (tree : St.tree) : t =
-        let r = ref tree in
-        let x = local' client repo r in
-        Hashtbl.replace client.Context.tx x r;
-        Capability.when_released x (fun () ->
-            Hashtbl.remove client.Context.tx x);
-        x
+        (* TODO: make this limit configurable *)
+        if Hashtbl.length client.Context.tx > tx_limit then
+          failwith "Too many transactions"
+        else
+          let r = ref tree in
+          let x = local' client repo r in
+          Hashtbl.replace client.Context.tx x r;
+          Capability.when_released x (fun () ->
+              Hashtbl.remove client.Context.tx x);
+          x
     end
 
     module Commit = struct

--- a/src/irmin-rpc/server_intf.ml
+++ b/src/irmin-rpc/server_intf.ml
@@ -9,16 +9,20 @@ module type S = sig
 
   type hash
 
-  module Context : sig
+  type ctx = { max_tx : int; repo : repo }
+
+  val ctx : ?max_tx:int -> repo -> ctx
+
+  module Client_context : sig
     type t
 
-    val empty : unit -> t
+    val empty : max_tx:int -> t
   end
 
   module Commit : sig
     type t = Raw.Client.Commit.t cap
 
-    val local : Context.t -> commit -> t
+    val local : Client_context.t -> commit -> t
 
     val read :
       repo ->
@@ -29,16 +33,16 @@ module type S = sig
   module Store : sig
     type t = Raw.Client.Store.t cap
 
-    val local : Context.t -> store -> t
+    val local : Client_context.t -> store -> t
   end
 
   module Repo : sig
     type t = Raw.Client.Repo.t cap
 
-    val local : Context.t -> repo -> t
+    val local : Client_context.t -> repo -> t
   end
 
-  val local : repo -> Raw.Client.Irmin.t cap
+  val local : ctx -> Raw.Client.Irmin.t cap
 end
 
 module type MAKER = functor

--- a/src/irmin-rpc/server_intf.ml
+++ b/src/irmin-rpc/server_intf.ml
@@ -9,10 +9,16 @@ module type S = sig
 
   type hash
 
+  module Context : sig
+    type t
+
+    val empty : unit -> t
+  end
+
   module Commit : sig
     type t = Raw.Client.Commit.t cap
 
-    val local : commit -> t
+    val local : Context.t -> commit -> t
 
     val read :
       repo ->
@@ -23,13 +29,13 @@ module type S = sig
   module Store : sig
     type t = Raw.Client.Store.t cap
 
-    val local : store -> t
+    val local : Context.t -> store -> t
   end
 
   module Repo : sig
     type t = Raw.Client.Repo.t cap
 
-    val local : repo -> t
+    val local : Context.t -> repo -> t
   end
 
   val local : repo -> Raw.Client.Irmin.t cap

--- a/test/test.ml
+++ b/test/test.ml
@@ -140,9 +140,11 @@ module Test_store = struct
     let info () = Faker.info () in
     let* master = Client.Store.master client in
     let* tree = Client.Tree.empty client in
-    let* tree = Client.Tree.add tree [ "a" ] (random_string 2048) in
-    let* tree = Client.Tree.add_tree tree [ "b" ] tree in
-    let* tree = Client.Tree.remove tree [ "b" ] in
+    let* tx = Client.Tx.v client tree in
+    let* () = Client.Tx.add tx [ "a" ] (random_string 2048) in
+    let* () = Client.Tx.add_tree tx [ "b" ] tree in
+    let* () = Client.Tx.remove tx [ "b" ] in
+    let* tree = Client.Tx.tree tx in
     let* () = Client.Store.set_tree master [ "tree" ] tree ~info in
     let* tree = Client.Tree.concrete tree >>= resolve_tree server in
     let* master = Server.master server in
@@ -183,9 +185,11 @@ module Test_store = struct
     let info () = Faker.info () in
     let* master = Client.Store.master client in
     let* tree = Client.Tree.empty client in
-    let* tree = Client.Tree.add tree [ "a" ] "1" in
-    let* tree = Client.Tree.add tree [ "b" ] "2" in
-    let* tree = Client.Tree.add tree [ "c" ] "3" in
+    let* tx = Client.Tx.v client tree in
+    let* () = Client.Tx.add tx [ "a" ] "1" in
+    let* () = Client.Tx.add tx [ "b" ] "2" in
+    let* () = Client.Tx.add tx [ "c" ] "3" in
+    let* tree = Client.Tx.tree tx in
     let* ok =
       Client.Store.test_and_set_tree master ~info [ "test"; "tree" ] ~test:None
         ~set:(Some tree)

--- a/test/test.ml
+++ b/test/test.ml
@@ -29,7 +29,7 @@ module Test_store = struct
 
   let ctx () =
     let+ server = Server.Repo.v (Irmin_mem.config ()) in
-    let ctx = RPC.Server.Context.empty () in
+    let ctx = RPC.Server.Client_context.empty ~max_tx:32 in
     let client = RPC.Server.Repo.local ctx server in
     { server; client }
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -145,8 +145,8 @@ module Test_store = struct
     let* () = Client.Tx.add tx [ "a" ] (random_string 2048) in
     let* () = Client.Tx.add_tree tx [ "b" ] tree in
     let* () = Client.Tx.remove tx [ "b" ] in
-    let* tree = Client.Tx.tree tx in
-    let* () = Client.Store.set_tree master [ "tree" ] tree ~info in
+    let* () = Client.Tx.commit tx master [ "tree" ] ~info in
+    let* tree = Client.Store.get_tree master [ "tree" ] in
     let* tree = Client.Tree.concrete tree >>= resolve_tree server in
     let* master = Server.master server in
     let* () =

--- a/test/test.ml
+++ b/test/test.ml
@@ -29,7 +29,8 @@ module Test_store = struct
 
   let ctx () =
     let+ server = Server.Repo.v (Irmin_mem.config ()) in
-    let client = RPC.Server.Repo.local server in
+    let ctx = RPC.Server.Context.empty () in
+    let client = RPC.Server.Repo.local ctx server in
     { server; client }
 
   let rec resolve_tree server (x : Client.Tree.concrete) =

--- a/test/test.ml
+++ b/test/test.ml
@@ -104,13 +104,13 @@ module Test_store = struct
     let* master = client |> Store.master in
     let* () =
       Client.Store.find_tree master [ "k" ]
-      >>= Option.map_lwt Client.Tree.concrete
+      >>= Option.map_lwt Client.Tree.to_concrete
       >>= Option.map_lwt (resolve_tree server)
       >|= Alcotest.(check find_tree) "Binding [k → Some tree]" (Some tree)
     in
     let* () =
       Client.Store.find_tree master [ "k_absent" ]
-      >>= Option.map_lwt Client.Tree.concrete
+      >>= Option.map_lwt Client.Tree.to_concrete
       >>= Option.map_lwt (resolve_tree server)
       >|= Alcotest.(check find_tree) "Binding [k_absent → Some tree]" None
     in
@@ -147,7 +147,7 @@ module Test_store = struct
     let* () = Client.Tx.remove tx [ "b" ] in
     let* () = Client.Tx.commit tx master [ "tree" ] ~info in
     let* tree = Client.Store.get_tree master [ "tree" ] in
-    let* tree = Client.Tree.concrete tree >>= resolve_tree server in
+    let* tree = Client.Tree.to_concrete tree >>= resolve_tree server in
     let* master = Server.master server in
     let* () =
       Server.find_tree master [ "tree" ]


### PR DESCRIPTION
This PR creates a distinction not found in the traditional Irmin API: `Tree`s are always immutable and `Tx`s are trees that can be modified. 

For example, an empty tree is converted into a `Tx` then modified and committed to the store (using the RPC client):
```ocaml
let* master = Store.master repo in
let* tree = Tree.empty repo in
let* tx = Repo.tx repo tree in
let* () = Tx.add tx ["a"; "b"; "c"] "123" in
let* () = Tx.add tx ["x"; "y"; "z"] "456" in
Tx.commit tx master ~info ["foo"]
```

This is a draft because I'm still working on some optimizations, current benchmarks are [here](https://hackmd.io/S4i3STEVSM2SVKWp_GZGzA)